### PR TITLE
As/emulate sample with nn hmc

### DIFF
--- a/emulate_sample/Project.toml
+++ b/emulate_sample/Project.toml
@@ -1,0 +1,6 @@
+[deps]
+AdvancedHMC = "0bf59076-c3b1-5ca4-86bd-e02cd72cde3d"
+Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
+GLMakie = "e9467ef8-e4e7-5192-8a1a-b1aee30e663a"
+JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
+ProgressBars = "49802e3a-d2f1-5c88-81d8-b72133a6f568"

--- a/emulate_sample/emulate_sample_catke.jl
+++ b/emulate_sample/emulate_sample_catke.jl
@@ -52,13 +52,26 @@ end
 
 ## Sample
 # HMC 
-scale = 1e3
-U = LogDensity(network, scale)
+scale = 1.0e2
+
+function regularize(x)
+    if any(x .≤ 0.0)
+        return -Inf
+    elseif any(x .> 8.0)
+        return -Inf
+    else
+        return 0.0
+    end
+    return 
+end
+regularization_scale = 1.0
+
+U = LogDensity(network, regularize, scale, regularization_scale)
 ∇U = GradientLogDensity(U)
 
 D = size(θr, 2)
 initial_θ = copy(θr[end, :])
-n_samples = 10000
+n_samples = 1000
 n_adapts = 1000
 
 metric = DiagEuclideanMetric(D)

--- a/emulate_sample/emulate_sample_catke.jl
+++ b/emulate_sample/emulate_sample_catke.jl
@@ -1,0 +1,89 @@
+using JLD2, Enzyme, ProgressBars, Random, Statistics, AdvancedHMC, GLMakie
+
+Random.seed!(1234)
+tic = time()
+include("simple_networks.jl")
+include("hmc_interface.jl")
+include("optimization_utils.jl")
+
+data_directory = "/Users/andresouza/Desktop/Repositories/GenericAnalysis.jl/"
+data_file = "catke_parameters.jld2"
+
+jlfile = jldopen(data_directory * data_file, "r")
+θ = jlfile["parameters"]
+y = jlfile["objectives"]
+close(jlfile)
+
+θr = reshape(θ, (size(θ)[1] * size(θ)[2], size(θ)[3]))
+yr = reshape(y, (size(y)[1] * size(y)[2]))
+M = size(θr)[1]
+Mᴾ = size(θr)[2]
+
+# Define Network
+Nθ = size(θr, 2)
+Nθᴴ = Nθ * 10
+W1 = randn(Nθᴴ, Nθ)
+b1 = randn(Nθᴴ)
+W2 = randn(1, Nθᴴ)
+b2 = randn(1)
+
+network = OneLayerNetwork(W1, b1, W2, b2)
+dnetwork = deepcopy(network)
+
+## Emulate
+# Optimize with Gradient Descent and Learning rate 1e-5
+batchsize = 10
+loss_list = Float64[]
+epochs = 10
+for i in ProgressBar(1:epochs)
+    shuffled_list = chunk_list(shuffle(1:M), batchsize)
+    loss_value = 0.0
+    N = length(shuffled_list)
+    for permuted_list in ProgressBar(shuffled_list)
+        θbatch = [θr[x, :] for x in permuted_list]
+        ybatch = yr[permuted_list]
+        zero!(dnetwork)
+        autodiff(Enzyme.Reverse, loss, Active, DuplicatedNoNeed(network, dnetwork), Const(θbatch), Const(ybatch))
+        update!(network, dnetwork, 1e-5)
+        loss_value += loss(network, θbatch, ybatch) / N
+    end
+    push!(loss_list, loss_value)
+end
+
+## Sample
+# HMC 
+scale = 1e3
+U = LogDensity(network, scale)
+∇U = GradientLogDensity(U)
+
+D = size(θr, 2)
+initial_θ = copy(θr[end, :])
+n_samples = 10000
+n_adapts = 1000
+
+metric = DiagEuclideanMetric(D)
+hamiltonian = Hamiltonian(metric, GaussianKinetic(), U, ∇U)
+
+initial_ϵ = find_good_stepsize(hamiltonian, initial_θ)
+integrator = Leapfrog(initial_ϵ)
+
+kernel = HMCKernel(Trajectory{MultinomialTS}(integrator, GeneralisedNoUTurn()))
+adaptor = StanHMCAdaptor(MassMatrixAdaptor(metric), StepSizeAdaptor(0.8, integrator))
+
+samples, stats = sample(hamiltonian, kernel, initial_θ, n_samples, adaptor, n_adapts; progress=true)
+
+toc = time()
+println("Elapsed time: $((toc - tic)/60) minutes")
+
+# Plot
+fig = Figure() 
+Mp = 5
+for i in 1:23
+    ii = (i-1)÷Mp + 1
+    jj = (i-1)%Mp + 1
+    ax = Axis(fig[ii, jj]; title = "Parameter $i")
+    v1 = [sample[i] for sample in samples]
+    hist!(ax, v1; bins = 50, strokewidth = 0, color = :blue, normalization = :pdf)
+    density!(ax, v1; color = (:red, 0.1), strokewidth = 3, strokecolor = :red)
+end
+display(fig)

--- a/emulate_sample/emulate_sample_catke.jl
+++ b/emulate_sample/emulate_sample_catke.jl
@@ -6,7 +6,7 @@ include("simple_networks.jl")
 include("hmc_interface.jl")
 include("optimization_utils.jl")
 
-data_directory = "/Users/andresouza/Desktop/Repositories/GenericAnalysis.jl/"
+data_directory = ""
 data_file = "catke_parameters.jld2"
 
 jlfile = jldopen(data_directory * data_file, "r")

--- a/emulate_sample/hmc_interface.jl
+++ b/emulate_sample/hmc_interface.jl
@@ -1,0 +1,38 @@
+struct LogDensity{N, S, M}
+    logp::N
+    regularization::S 
+    scale::M
+    scale_regularization::M
+end
+
+# Negative sign if the network represents the potential function
+# Note: regularization should be negative semi-definite
+function (logp::LogDensity{T})(θ) where T <: SimpleNetwork 
+    return -logp.logp(θ)[1] * logp.scale + logp.regularization(θ) * logp.scale_regularization
+end
+
+function LogDensity(network::SimpleNetwork)
+    regularization(x) = 0.0
+    return LogDensity(network, regularization, 1.0, 1.0)
+end
+
+function LogDensity(network::SimpleNetwork, scale)
+    regularization(x) = 0.0
+    return LogDensity(network, regularization, scale, 1.0)
+end
+
+struct GradientLogDensity{N}
+    logp::N 
+    dθ::Vector{Float64}
+end
+
+function GradientLogDensity(logp::LogDensity{S}) where S <: SimpleNetwork
+    dθ = zeros(size(logp.logp.W1, 2))
+    return GradientLogDensity(logp, dθ)
+end
+
+function (∇logp::GradientLogDensity)(θ)
+    ∇logp.dθ .= 0.0
+    autodiff(Enzyme.Reverse, Const(∇logp.logp), Active, DuplicatedNoNeed(θ, ∇logp.dθ))
+    return (∇logp.logp(θ),  copy(∇logp.dθ))
+end

--- a/emulate_sample/optimization_utils.jl
+++ b/emulate_sample/optimization_utils.jl
@@ -1,0 +1,85 @@
+function loss(network::SimpleNetwork, x, y)
+    ŷ = similar(y)
+    for i in eachindex(ŷ)
+        ŷ[i] = predict(network, x[i])[1]
+    end
+    return mean((y .- ŷ) .^ 2)
+end
+
+function chunk_list(list, n)
+    return [list[i:i+n-1] for i in 1:n:length(list)]
+end
+
+struct Adam{S, T, I}
+    struct_copies::S
+    parameters::T 
+    t::I
+end
+
+function parameters(network::SimpleNetwork)
+    network_parameters = []
+    for names in propertynames(network)
+        push!(network_parameters, getproperty(network, names)[:])
+    end
+    param_lengths = [length(params) for params in network_parameters]
+    parameter_list = zeros(sum(param_lengths))
+    start = 1
+    for i in 1:length(param_lengths)
+        parameter_list[start:start+param_lengths[i]-1] .= network_parameters[i]
+        start += param_lengths[i]
+    end
+    return parameter_list
+end
+
+function set_parameters!(network::SimpleNetwork, parameters_list)
+    param_lengths = Int64[]
+    for names in propertynames(network)
+        push!(param_lengths, length(getproperty(network, names)[:]))
+    end
+    start = 1
+    for (i, names) in enumerate(propertynames(network))
+        getproperty(network, names)[:] .= parameters_list[start:start+param_lengths[i]-1]
+    end
+    return nothing
+end
+
+function Adam(network::SimpleNetwork)
+    parameters_list = (; α = 0.001, β₁ = 0.9, β₂ = 0.999, ϵ = 1e-8)
+    network_parameters = parameters(network)
+    t = [1.0]
+    θ  = deepcopy(network_parameters) .* 0.0
+    gₜ = deepcopy(network_parameters) .* 0.0
+    m₀ = deepcopy(network_parameters) .* 0.0
+    mₜ = deepcopy(network_parameters) .* 0.0
+    v₀ = deepcopy(network_parameters) .* 0.0
+    vₜ = deepcopy(network_parameters) .* 0.0
+    v̂ₜ = deepcopy(network_parameters) .* 0.0
+    m̂ₜ = deepcopy(network_parameters) .* 0.0
+    struct_copies = (; θ, gₜ, m₀, mₜ, v₀, vₜ, v̂ₜ, m̂ₜ)
+    return Adam(struct_copies, parameters_list,  t)
+end
+
+function update!(adam::Adam, network::SimpleNetwork, dnetwork::SimpleNetwork)
+    # unpack
+    (; α, β₁, β₂, ϵ) = adam.parameters
+    t = adam.t[1]
+    (; θ, gₜ, m₀, mₜ, v₀, vₜ, v̂ₜ, m̂ₜ) = adam.struct_copies
+    t = adam.t[1]
+    # get gradient
+    θ .= parameters(network)
+    gₜ .= parameters(dnetwork)
+    # update
+    @. m₀ = β₁ * m₀
+    @. mₜ = m₀ + (1 - β₁) * gₜ
+    @. v₀ = β₂ * v₀
+    @. vₜ = v₀ + (1 - β₂) * (gₜ .^2)
+    @. v̂ₜ = vₜ / (1 - β₂^t)
+    @. m̂ₜ = mₜ / (1 - β₁^t)
+    @. θ  = θ - α * m̂ₜ / (sqrt(v̂ₜ) + ϵ)
+    # update parameters
+    m₀ .= mₜ
+    v₀ .= vₜ
+    adam.t[1] += 1
+    set_parameters!(network, θ)
+    return nothing
+end

--- a/emulate_sample/simple_networks.jl
+++ b/emulate_sample/simple_networks.jl
@@ -1,0 +1,41 @@
+using Enzyme
+
+abstract type SimpleNetwork end
+
+struct OneLayerNetwork{M, V} <: SimpleNetwork
+    W1::M
+    b1::V
+    W2::M
+    b2::V
+end
+
+function zero!(dnetwork::OneLayerNetwork)
+    dnetwork.W1 .= 0.0
+    dnetwork.b1 .= 0.0
+    dnetwork.W2 .= 0.0
+    dnetwork.b2 .= 0.0
+    return nothing
+end
+
+function update!(network::SimpleNetwork, dnetwork::SimpleNetwork, η)
+    network.W1 .-= η .* dnetwork.W1
+    network.b1 .-= η .* dnetwork.b1
+    network.W2 .-= η .* dnetwork.W2
+    network.b2 .-= η .* dnetwork.b2
+    return nothing
+end
+
+swish(x) = x / (1 + exp(-x))
+activation_function(x) = tanh(x) 
+
+function predict(network::OneLayerNetwork, x)
+    return abs.(network.W2 * activation_function.(network.W1 * x .+ network.b1) .+ network.b2)
+end
+
+function predict(network::OneLayerNetwork, x, activation::Function)
+    return abs.(network.W2 * activation.(network.W1 * x .+ network.b1) .+ network.b2)
+end
+
+function (network::SimpleNetwork)(x)
+    return predict(network, x)
+end


### PR DESCRIPTION
Adds an emulate-sample example using a neural network and hamiltonian monte-carlo. Enzyme is used for autodiff. The example runs in about 2 minutes on a local laptop. This is done as a separate directory and is meant as a discussion point rather than user-friendly "emulate sample" framework (which would better go in the CalibrateEmulateSample package)
