### PR TITLE
Remove auto_prs option from CompatHelper.main() execution in workflow

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -19,4 +19,4 @@ jobs:
       - name: CompatHelper.main()
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: julia -e 'using CompatHelper; CompatHelper.main(; auto_prs=true)'
+        run: julia -e 'using CompatHelper; CompatHelper.main()'


### PR DESCRIPTION
apparently autopr doesn't work